### PR TITLE
Do not comment if the backport was successful

### DIFF
--- a/lib/backport.js
+++ b/lib/backport.js
@@ -100,8 +100,6 @@ module.exports = async function (context, targets, logger) {
         await pullRequest.setMilestone(context, milestoneId, newPrId)
       }
 
-      // Comment success
-      await pullRequest.backportSuccess(context, target, newPrId, conflicts)
       logger.info('Successfully created backport from', oldBranch, 'for', target.branch, 'in', branch)
     } catch (e) {
       logger.debug(e)

--- a/lib/pr.js
+++ b/lib/pr.js
@@ -120,19 +120,6 @@ module.exports = {
     )
   },
 
-  backportSuccess: async function (context, target, issueId, conflicts) {
-    let body = 'backport to ' + target.branch + ' in #' + issueId
-
-    if (conflicts) {
-      body += ' with conflicts :warning: '
-    }
-    return context.github.issues.createComment(
-      context.issue({
-        body: body
-      })
-    )
-  },
-
   getReviewers: async function (context) {
     const reviewers1 = await context.github.pulls.listReviewRequests(context.issue())
     const reviewers2 = await context.github.pulls.listReviews(context.issue())


### PR DESCRIPTION
Github will show the reference already, this comment will otherwise
trigger a notification for all participants with very little use as they
are notified about the PR anyway.